### PR TITLE
Fix HTML class attribute in `GetChapterListSteps`

### DIFF
--- a/chapter.go
+++ b/chapter.go
@@ -148,7 +148,7 @@ func GetChapterListSteps() []*Step {
 	steps[6] = &Step {
 		Element: "div",
 		Id: "",
-		Class: "detail_body challenge",
+		Class: "detail_body banner",
 	}
 
 	steps[7] = &Step {


### PR DESCRIPTION
The program always prints "number of retrieved chapters is 0, are you sure you input the correct url?" because the chapters could not be parsed from the pages. It seems that a HTML class attribute has changed.